### PR TITLE
Make metric label full height of treemap header for more predictable positioning of series picker.

### DIFF
--- a/stylesheets/treemap.less
+++ b/stylesheets/treemap.less
@@ -78,6 +78,12 @@
   right: 0;
   z-index: 1000;
 
+  > span {
+    vertical-align: top;
+    line-height: 23px;
+    height: 23px;
+  }
+
   > .jqplot-seriespicker {
     display: inline-block;
     position: relative;


### PR DESCRIPTION
Specifically for this PR in core: https://github.com/piwik/piwik/pull/11905