### PR TITLE
Use registerEvents instead of getListHooksRegistered, as it is deprecated

### DIFF
--- a/TreemapVisualization.php
+++ b/TreemapVisualization.php
@@ -23,7 +23,7 @@ require_once PIWIK_INCLUDE_PATH . '/plugins/TreemapVisualization/Visualizations/
  */
 class TreemapVisualization extends \Piwik\Plugin
 {
-    public function getListHooksRegistered()
+    public function registerEvents()
     {
         return array(
             'AssetManager.getStylesheetFiles' => 'getStylesheetFiles',


### PR DESCRIPTION
`getListHooksRegistered` is deprecated since Piwik 2.15. So should be safe to merge directly.