### PR TITLE
Only allow calling Treemap API directly

### DIFF
--- a/API.php
+++ b/API.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\TreemapVisualization;
 
 use Piwik\API\Request;
 use Piwik\Common;
+use Piwik\DataTable;
 use Piwik\Metrics;
 use Piwik\Period\Range;
 use Piwik\Plugins\TreemapVisualization\Visualizations\Treemap;
@@ -48,7 +49,7 @@ class API extends \Piwik\Plugin\API
         $availableHeight = false,
         $show_evolution_values = false
     ) {
-        if (trim($apiMethod) === 'TreemapVisualization.getTreemapData') {
+        if (!Request::isCurrentApiRequestTheRootApiRequest()) {
             return [];
         }
 
@@ -69,6 +70,10 @@ class API extends \Piwik\Plugin\API
         $params['disable_queued_filters'] = true;
 
         $dataTable = Request::processRequest("$apiMethod", $params);
+
+        if (!$dataTable instanceof DataTable) {
+            return [];
+        }
 
         $columns = explode(',', $column);
         $column  = reset($columns);


### PR DESCRIPTION
### Description:

The Treemap API is meant to be called by the visualization only. Therefor there is no need to allow calling the API from within another API method.

Furthermore I've added a check that the called API actually returns a DataTable, if that isn't the case it would otherwise throw errors when trying to use the returned value as a DataTable.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
