### PR TITLE
Added validation rule for apiMethod parameter in getTreemapData API call, #AS-494

### DIFF
--- a/API.php
+++ b/API.php
@@ -52,6 +52,12 @@ class API extends \Piwik\Plugin\API
         if (!Request::isCurrentApiRequestTheRootApiRequest()) {
             return [];
         }
+        list($apiName, $apiAction) = explode('.', $apiMethod);
+        $disAllowedApiActions = ['getBulkRequest'];
+        // Block id API action does not start with get
+        if (!in_array($apiAction, $disAllowedApiActions)|| stripos($apiAction, 'get') !== 0) {
+            throw new \Exception('Invalid API method');
+        }
 
         if (
             $period == 'range'

--- a/API.php
+++ b/API.php
@@ -15,6 +15,7 @@ use Piwik\Common;
 use Piwik\DataTable;
 use Piwik\Metrics;
 use Piwik\Period\Range;
+use Piwik\Piwik;
 use Piwik\Plugins\TreemapVisualization\Visualizations\Treemap;
 
 /**
@@ -56,7 +57,7 @@ class API extends \Piwik\Plugin\API
         $disAllowedApiActions = ['getBulkRequest'];
         // Block id API action does not start with get
         if (!in_array($apiAction, $disAllowedApiActions)|| stripos($apiAction, 'get') !== 0) {
-            throw new \Exception('Invalid API method');
+            throw new \Exception(Piwik::translate('TreemapVisualization_InvalidApiMethodException'));
         }
 
         if (

--- a/API.php
+++ b/API.php
@@ -56,7 +56,7 @@ class API extends \Piwik\Plugin\API
         list($apiName, $apiAction) = explode('.', $apiMethod);
         $disAllowedApiActions = ['getBulkRequest'];
         // Block id API action does not start with get
-        if (!in_array($apiAction, $disAllowedApiActions)|| stripos($apiAction, 'get') !== 0) {
+        if (!in_array($apiAction, $disAllowedApiActions) || stripos($apiAction, 'get') !== 0) {
             throw new \Exception(Piwik::translate('TreemapVisualization_InvalidApiMethodException'));
         }
 

--- a/API.php
+++ b/API.php
@@ -55,7 +55,7 @@ class API extends \Piwik\Plugin\API
         }
         list($apiName, $apiAction) = explode('.', $apiMethod);
         $disAllowedApiActions = ['getBulkRequest'];
-        // Block id API action does not start with get
+        // Block if API action does not start with get
         if (!in_array($apiAction, $disAllowedApiActions) || stripos($apiAction, 'get') !== 0) {
             throw new \Exception(Piwik::translate('TreemapVisualization_InvalidApiMethodException'));
         }

--- a/API.php
+++ b/API.php
@@ -57,7 +57,7 @@ class API extends \Piwik\Plugin\API
         list($module, $method) = explode('.', $apiMethod);
         $disAllowedApiActions = ['getBulkRequest'];
         // Block if API action does not start with get
-        if (in_array($method, $disAllowedApiActions) || stripos($method, 'get') !== 0) {
+        if (!$method || in_array(strtolower($method), $disAllowedApiActions) || stripos($method, 'get') !== 0) {
             throw new BadRequestException(Piwik::translate('TreemapVisualization_InvalidApiMethodException'));
         }
 

--- a/API.php
+++ b/API.php
@@ -13,6 +13,7 @@ namespace Piwik\Plugins\TreemapVisualization;
 use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\DataTable;
+use Piwik\Http\BadRequestException;
 use Piwik\Metrics;
 use Piwik\Period\Range;
 use Piwik\Piwik;
@@ -53,11 +54,11 @@ class API extends \Piwik\Plugin\API
         if (!Request::isCurrentApiRequestTheRootApiRequest()) {
             return [];
         }
-        list($apiName, $apiAction) = explode('.', $apiMethod);
+        list($module, $method) = explode('.', $apiMethod);
         $disAllowedApiActions = ['getBulkRequest'];
         // Block if API action does not start with get
-        if (!in_array($apiAction, $disAllowedApiActions) || stripos($apiAction, 'get') !== 0) {
-            throw new \Exception(Piwik::translate('TreemapVisualization_InvalidApiMethodException'));
+        if (in_array($method, $disAllowedApiActions) || stripos($method, 'get') !== 0) {
+            throw new BadRequestException(Piwik::translate('TreemapVisualization_InvalidApiMethodException'));
         }
 
         if (

--- a/API.php
+++ b/API.php
@@ -51,13 +51,13 @@ class API extends \Piwik\Plugin\API
         $availableHeight = false,
         $show_evolution_values = false
     ) {
-        if (!Request::isCurrentApiRequestTheRootApiRequest()) {
+        if (!Request::isCurrentApiRequestTheRootApiRequest() && !defined('PIWIK_TEST_MODE')) {
             return [];
         }
         list($module, $method) = explode('.', $apiMethod);
         $disAllowedApiActions = ['getBulkRequest'];
         // Block if API action does not start with get
-        if (!$method || in_array(strtolower($method), $disAllowedApiActions) || stripos($method, 'get') !== 0) {
+        if (!$method || in_array($method, $disAllowedApiActions) || stripos($method, 'get') !== 0) {
             throw new BadRequestException(Piwik::translate('TreemapVisualization_InvalidApiMethodException'));
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+# 5.0.5 - 2026-02-16
+- Added validation rules for ApiAction
+
 # 5.0.4 - 2025-07-07
 - Textual changes
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,6 +1,7 @@
 {
     "TreemapVisualization": {
         "PluginDescription": "Visualise any report in Matomo as a Treemap. Click on the Treemap icon in each report to load the visualisation.",
-        "Treemap": "Treemap"
+        "Treemap": "Treemap",
+        "InvalidApiMethodException": "Invalid API method."
     }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,10 +1,7 @@
 {
     "name": "TreemapVisualization",
     "version": "5.0.4",
-    "description": "Visualise any report in Matomo as a Treemap. Click on the Treemap icon in each report to load the visualisation.",
-    "keywords": ["treemap", "graph", "visualization", "infovis", "jit"],
-    "license": "GPL v3+",
-    "homepage": "https://matomo.org",
+    "description": "Visualis5tps://matomo.org",
     "require": {
         "matomo": ">=5.0.0-b1,<6.0.0-b1"
     },

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "TreemapVisualization",
-    "version": "5.0.4",
+    "version": "5.0.5",
     "description": "Visualise any report in Matomo as a Treemap. Click on the Treemap icon in each report to load the visualisation.",
     "keywords": ["treemap", "graph", "visualization", "infovis", "jit"],
     "license": "GPL v3+",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,10 @@
 {
     "name": "TreemapVisualization",
     "version": "5.0.4",
-    "description": "Visualis5tps://matomo.org",
+    "description": "Visualise any report in Matomo as a Treemap. Click on the Treemap icon in each report to load the visualisation.",
+    "keywords": ["treemap", "graph", "visualization", "infovis", "jit"],
+    "license": "GPL v3+",
+    "homepage": "https://matomo.org",
     "require": {
         "matomo": ">=5.0.0-b1,<6.0.0-b1"
     },

--- a/tests/Integration/ApiTest.php
+++ b/tests/Integration/ApiTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TreemapVisualization\tests\Integration;
+
+use Piwik\Http\BadRequestException;
+use Piwik\Plugins\TreemapVisualization\API;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group TreemapVisualization
+ * @group ApiTest
+ * @group Plugins
+ */
+class ApiTest extends IntegrationTestCase
+{
+    private $api;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createSuperUser();
+        $this->api = API::getInstance();
+    }
+
+    /**
+     * @dataProvider validMethod
+     */
+    public function testGetTreemapDataAllowsValidApiMethod($method): void
+    {
+        $result = $this->api->getTreemapData(
+            $method,
+            'nb_visits',
+            'day',
+            '2025-02-03'
+        );
+
+        $this->assertIsArray($result);
+    }
+
+    /**
+     * @dataProvider inValidMethod
+     */
+    public function testGetTreemapDataRejectsInvalidApiMethod($method): void
+    {
+        $this->expectException(BadRequestException::class);
+        $this->api->getTreemapData(
+            $method,
+            'nb_visits',
+            'day',
+            '2025-02-03'
+        );
+    }
+
+    public function validMethod()
+    {
+        return [
+            ['API.getMatomoVersion'],
+            ['API.getPhpVersion'],
+        ];
+    }
+
+    public function inValidMethod()
+    {
+        return [
+            ['API.getBulkRequest'],
+            ['UsersManager.deleteUser'],
+        ];
+    }
+}


### PR DESCRIPTION
## Description
Added validation rule for apiMethod parameter in getTreemapData API call

## Issue No
#AS-494

## Steps to Replicate the Issue
1. It should block requests like below
```
/index.php?module=API&action=index&method=TreemapVisualization.getTreemapData&idSite=6&period=day&date=2026-01-01&apiMethod=SitesManager.deleteSite&column=something
```



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✖] New test case added/updated?
- [✔] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
