### PR TITLE
Fix typo: matono-org → matomo-org in README.md feedback link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Each treemap square is colored based on the evolution value **so you can easily 
 * Evolution values cannot be calculated for subtables (reports that are displayed when you click on a row or node).
 
 #### Feedback, bug report or requests
- [github.com/matono-org/plugin-TreemapVisualization/issues](https://github.com/matomo-org/plugin-TreemapVisualization/issues)
+ [github.com/matomo-org/plugin-TreemapVisualization/issues](https://github.com/matomo-org/plugin-TreemapVisualization/issues)


### PR DESCRIPTION
Fixes issue #91

Changed `matono-org` → `matomo-org` in the display text of the feedback link.
The hyperlink URL was already correct.