### PR TITLE
Improvements in treemap node URL handling, AS-706

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 6.0.0 - 2026-08-09
 - Compatibility with Matomo 6
+- Improvements in treemap node URL handling
 
 # 5.0.7 - 2026-04-27
 - Updated API documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Changelog
 
+# 6.0.1 - 2026-09-07
+- Improvements in treemap node URL handling
+
 # 6.0.0 - 2026-08-09
 - Compatibility with Matomo 6
-- Improvements in treemap node URL handling
 
 # 5.0.7 - 2026-04-27
 - Updated API documentation

--- a/TreemapDataGenerator.php
+++ b/TreemapDataGenerator.php
@@ -352,7 +352,9 @@ class TreemapDataGenerator
      */
     private static function makeUrlSafeToOpen($url)
     {
-        if (!UrlHelper::isLookLikeSafeUrl($url)) {
+        // a blank URL would end up as the bare scheme below, which shows the link icon on a row
+        // that has no URL at all
+        if (trim($url) === '' || !UrlHelper::isLookLikeSafeUrl($url)) {
             return null;
         }
 

--- a/TreemapDataGenerator.php
+++ b/TreemapDataGenerator.php
@@ -16,6 +16,7 @@ use Piwik\DataTable;
 use Piwik\DataTable\Filter\CalculateEvolutionFilter;
 use Piwik\DataTable\Map;
 use Piwik\Piwik;
+use Piwik\UrlHelper;
 
 /**
  * A utility class that generates JSON data meant to be used with the JavaScript
@@ -281,6 +282,14 @@ class TreemapDataGenerator
                     $data['metadata'][$metadataName] = $metadataValue;
                 }
             }
+
+            if (isset($data['metadata']['url'])) {
+                $data['metadata']['url'] = self::makeUrlSafeToOpen($data['metadata']['url']);
+
+                if ($data['metadata']['url'] === null) {
+                    unset($data['metadata']['url']);
+                }
+            }
         }
 
         // add evolution
@@ -330,5 +339,28 @@ class TreemapDataGenerator
     private function makeNode($id, $title, $data = array())
     {
         return array('id' => $id, 'name' => $title, 'data' => $data, 'children' => array());
+    }
+
+    /**
+     * Returns a URL that is safe to open in the browser or null, if the URL cannot be made safe.
+     *
+     * The URL metadata of a row is based on tracked data and can use any scheme, while the treemap
+     * opens the URL of a node when the node is clicked.
+     *
+     * @param string $url
+     * @return string|null
+     */
+    private static function makeUrlSafeToOpen($url)
+    {
+        if (!UrlHelper::isLookLikeSafeUrl($url)) {
+            return null;
+        }
+
+        if (strpos($url, ':') === false) {
+            // a URL without a scheme would be opened relative to the Matomo URL
+            $url = 'http://' . $url;
+        }
+
+        return $url;
     }
 }

--- a/javascripts/treemapViz.js
+++ b/javascripts/treemapViz.js
@@ -408,13 +408,21 @@
 
         /**
          * If the given node has an associated URL, it is opened in a new tab/window.
+         *
+         * The URL is based on tracked data, so it is checked again here before it is opened.
          */
         _openNodeUrl: function (node) {
-            if (node.data.metadata
-                && node.data.metadata.url
-                ) {
-                window.open(node.data.metadata.url, '_blank');
+            if (!node.data.metadata || !node.data.metadata.url) {
+                return;
             }
+
+            var url = window.vueSanitizeUrl(node.data.metadata.url);
+
+            if (!url) {
+                return;
+            }
+
+            window.open(url, '_blank', 'noopener,noreferrer');
         },
 
         /**

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "TreemapVisualization",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "description": "Visualise any report in Matomo as a Treemap. Click on the Treemap icon in each report to load the visualisation.",
     "keywords": ["treemap", "graph", "visualization", "infovis", "jit"],
     "license": "GPL v3+",

--- a/tests/Unit/TreemapDataGeneratorTest.php
+++ b/tests/Unit/TreemapDataGeneratorTest.php
@@ -58,6 +58,8 @@ class TreemapDataGeneratorTest extends UnitTestCase
             'scheme that is not allowed'       => array('cylon://example.com/path', null),
             'scheme without a host'            => array('rtp:0/path', null),
             'url with a control character'     => array("http://example.com/\x01", null),
+            'empty url'                        => array('', null),
+            'whitespace only url'              => array('  ', null),
         );
     }
 }

--- a/tests/Unit/TreemapDataGeneratorTest.php
+++ b/tests/Unit/TreemapDataGeneratorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TreemapVisualization\tests\Unit;
+
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+use Piwik\Plugins\TreemapVisualization\TreemapDataGenerator;
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
+
+/**
+ * @group TreemapVisualization
+ * @group TreemapDataGeneratorTest
+ * @group Plugins
+ */
+class TreemapDataGeneratorTest extends UnitTestCase
+{
+    /**
+     * @dataProvider getUrlMetadataTestData
+     */
+    public function testGenerateOnlyKeepsUrlMetadataThatIsSafeToOpen($url, $expectedUrl): void
+    {
+        $dataTable = new DataTable();
+        $dataTable->addRow(new Row(array(
+            Row::COLUMNS  => array('label' => 'row label', 'nb_visits' => 5),
+            Row::METADATA => array('url' => $url),
+        )));
+
+        $generator = new TreemapDataGenerator('nb_visits', 'visits');
+        $result    = $generator->generate($dataTable);
+
+        $metadata = $result['children'][0]['data']['metadata'];
+
+        if ($expectedUrl === null) {
+            $this->assertArrayNotHasKey('url', $metadata);
+        } else {
+            $this->assertSame($expectedUrl, $metadata['url']);
+        }
+    }
+
+    /**
+     * Whether a scheme is safe is decided by `UrlHelper::isLookLikeSafeUrl()`, which core tests
+     * separately, so the cases below only need to cover allowed and not allowed schemes.
+     */
+    public function getUrlMetadataTestData(): array
+    {
+        return array(
+            'allowed scheme is kept'           => array('http://example.com/path', 'http://example.com/path'),
+            'allowed secure scheme is kept'    => array('https://example.com/path', 'https://example.com/path'),
+            'other allowed scheme is kept'     => array('mailto:someone@example.com', 'mailto:someone@example.com'),
+            'url without scheme gets a scheme' => array('example.com/path', 'http://example.com/path'),
+            'scheme that is not allowed'       => array('cylon://example.com/path', null),
+            'scheme without a host'            => array('rtp:0/path', null),
+            'url with a control character'     => array("http://example.com/\x01", null),
+        );
+    }
+}


### PR DESCRIPTION
## Description

Forward-ports #102 to `6.x-dev`, so a treemap only opens node URLs that are safe to open.

A row's `url` metadata comes from tracked data and can use any scheme, and the treemap opens it when a node is clicked. It is now filtered through `UrlHelper::isLookLikeSafeUrl()` before it becomes part of the treemap data, a URL without a scheme is prefixed with `http://` so it is not resolved against the Matomo URL, the browser checks it again with `window.vueSanitizeUrl()`, and the new window no longer gets access to the opener document.

Two deliberate differences from the 5.x change:

- 5.x calls `window.vueSanitizeUrl` only where it exists, because the plugin supports Matomo 5.0 and the helper arrived in 5.11. Every Matomo this branch supports ships it, so the guard is dropped.
- A blank `url` metadata passed the safety check and picked up the `http://` prefix, which put a link icon on rows such as "Page URL not defined" — that is what moved the screenshot on 5.x. The second commit drops blank URLs instead, so those rows render as they did before and the 6.x baseline is left as it is. The same fix is still owed on `5.x-dev`.

Released as 6.0.1, since 6.0.0 is already out.

Verified locally: PHPCS and PHPStan clean on the changed files, and the plugin's unit tests pass (9/9).

## Issue No

AS-706 — forward-port of #102.

## Steps to Replicate the Issue

See #102; the behaviour and the tests are the same on this branch.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?

